### PR TITLE
Fix GCC12 compilation

### DIFF
--- a/index4D.h
+++ b/index4D.h
@@ -2,6 +2,7 @@
 #define INDEX4D_H
 
 #include <tuple>
+#include <array>
 
 //! type of 4D matrix -- left, middle, right, outer
 enum class MType { L, M, R, O };


### PR DESCRIPTION
Using GCC 12.2.0 and Cmake 3.25.1, I got the following compilation error when building Knotty. 

`Knotty/index4D.h:12:38: error: variable ‘std::array<std::__cxx11::basic_string<char>, 4> symbol’ has initializer but incomplete type
   12 |     static std::array<std::string,4> symbol {"L","M","R","O"};`

This appears to stem from a change in GCC 12 eliminating implicit includes of certain standard library components. From [the guide](https://gcc.gnu.org/gcc-12/porting_to.html), "C++ programs that used standard library components without including the right headers will no longer compile."

This commit adds `#include <array>` to index4D.h to correct the compilation error and make Knotty build with GCC 12.